### PR TITLE
fix: :fire: remove 'usingSmallUtilityStyles'  from styles files

### DIFF
--- a/src/styles/DefaultAppStyles.js
+++ b/src/styles/DefaultAppStyles.js
@@ -3,6 +3,6 @@ import { DefaultCoreStyles } from "@wrappid/core";
 export default class DefaultAppStyles extends DefaultCoreStyles {
   constructor(){
     super();
-    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
+    this.style = {};
   }
 }

--- a/src/styles/DefaultAppStyles.js
+++ b/src/styles/DefaultAppStyles.js
@@ -3,11 +3,6 @@ import { DefaultCoreStyles } from "@wrappid/core";
 export default class DefaultAppStyles extends DefaultCoreStyles {
   constructor(){
     super();
-    this.style = {
-      /**************************************************
-       * Using defaultUtilityStyles example
-       *************************************************/
-      usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles },
-    };
+    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
   }
 }

--- a/src/styles/DefaultAppStyles.js
+++ b/src/styles/DefaultAppStyles.js
@@ -3,6 +3,6 @@ import { DefaultCoreStyles } from "@wrappid/core";
 export default class DefaultAppStyles extends DefaultCoreStyles {
   constructor(){
     super();
-    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
+    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
   }
 }

--- a/src/styles/LargeAppStyles.js
+++ b/src/styles/LargeAppStyles.js
@@ -3,6 +3,6 @@ import { LargeCoreStyles } from "@wrappid/core";
 export default class LargeAppStyles extends LargeCoreStyles {
   constructor() {
     super();
-    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
+    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
   }
 }

--- a/src/styles/LargeAppStyles.js
+++ b/src/styles/LargeAppStyles.js
@@ -3,11 +3,6 @@ import { LargeCoreStyles } from "@wrappid/core";
 export default class LargeAppStyles extends LargeCoreStyles {
   constructor() {
     super();
-    this.style = {
-      /**************************************************
-       * Using LargeUtilityStyles example
-       *************************************************/
-      usingLargeUtilityStyles: { ...this.LargeUtilityStyles.anyUtilityStyle },
-    };
+    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
   }
 }

--- a/src/styles/LargeAppStyles.js
+++ b/src/styles/LargeAppStyles.js
@@ -3,6 +3,6 @@ import { LargeCoreStyles } from "@wrappid/core";
 export default class LargeAppStyles extends LargeCoreStyles {
   constructor() {
     super();
-    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
+    this.style = {}; 
   }
 }

--- a/src/styles/MediumAppStyles.js
+++ b/src/styles/MediumAppStyles.js
@@ -3,6 +3,6 @@ import { MediumCoreStyles } from "@wrappid/core";
 export default class MediumAppStyles extends MediumCoreStyles {
   constructor() {
     super();
-    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
+    this.style = {};
   }
 }

--- a/src/styles/MediumAppStyles.js
+++ b/src/styles/MediumAppStyles.js
@@ -3,11 +3,6 @@ import { MediumCoreStyles } from "@wrappid/core";
 export default class MediumAppStyles extends MediumCoreStyles {
   constructor() {
     super();
-    this.style = {
-      /**************************************************
-       * Using mediumUtilityStyles example
-       *************************************************/
-      usingMediumUtilityStyles: { ...this.mediumUtilityStyles.anyUtilityStyle },
-    };
+    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
   }
 }

--- a/src/styles/MediumAppStyles.js
+++ b/src/styles/MediumAppStyles.js
@@ -3,6 +3,6 @@ import { MediumCoreStyles } from "@wrappid/core";
 export default class MediumAppStyles extends MediumCoreStyles {
   constructor() {
     super();
-    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
+    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
   }
 }

--- a/src/styles/SmallAppStyles.js
+++ b/src/styles/SmallAppStyles.js
@@ -3,6 +3,6 @@ import { SmallCoreStyles } from "@wrappid/core";
 export default class SmallAppStyles extends SmallCoreStyles {
   constructor() {
     super();
-    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
+    this.style = {};
   }
 }

--- a/src/styles/SmallAppStyles.js
+++ b/src/styles/SmallAppStyles.js
@@ -3,6 +3,6 @@ import { SmallCoreStyles } from "@wrappid/core";
 export default class SmallAppStyles extends SmallCoreStyles {
   constructor() {
     super();
-    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
+    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };
   }
 }

--- a/src/styles/SmallAppStyles.js
+++ b/src/styles/SmallAppStyles.js
@@ -3,11 +3,6 @@ import { SmallCoreStyles } from "@wrappid/core";
 export default class SmallAppStyles extends SmallCoreStyles {
   constructor() {
     super();
-    this.style = {
-      /**************************************************
-       * Using smallUtilityStyles example
-       *************************************************/
-      usingSmallUtilityStyles: { ...this.smallUtilityStyles.anyUtilityStyle },
-    };
+    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
   }
 }

--- a/src/styles/XLargeAppStyles.js
+++ b/src/styles/XLargeAppStyles.js
@@ -3,11 +3,6 @@ import { XLargeCoreStyles } from "@wrappid/core";
 export default class XLargeAppStyles extends XLargeCoreStyles {
   constructor() {
     super();
-    this.style = {
-      /**************************************************
-       * Using XLargeUtilityStyles example
-       *************************************************/
-      usingXLargeUtilityStyles: { ...this.xLargeUtilityStyles.anyUtilityStyle },
-    };
+    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
   }
 }

--- a/src/styles/XLargeAppStyles.js
+++ b/src/styles/XLargeAppStyles.js
@@ -3,6 +3,5 @@ import { XLargeCoreStyles } from "@wrappid/core";
 export default class XLargeAppStyles extends XLargeCoreStyles {
   constructor() {
     super();
-    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
-  }
+    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };}
 }

--- a/src/styles/XLargeAppStyles.js
+++ b/src/styles/XLargeAppStyles.js
@@ -3,5 +3,6 @@ import { XLargeCoreStyles } from "@wrappid/core";
 export default class XLargeAppStyles extends XLargeCoreStyles {
   constructor() {
     super();
-    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };}
+    this.style = {};
+  }
 }

--- a/src/styles/XXLargeAppStyles.js
+++ b/src/styles/XXLargeAppStyles.js
@@ -3,11 +3,6 @@ import { XXLargeCoreStyles } from "@wrappid/core";
 export default class XXLargeAppStyles extends XXLargeCoreStyles {
   constructor() {
     super();
-    this.style = {
-      /**************************************************
-       * Using XXLargeUtilityStyles example
-       *************************************************/
-      usingXXLargeUtilityStyles: { ...this.xXLargeUtilityStyles.anyUtilityStyle },
-    };
+    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
   }
 }

--- a/src/styles/XXLargeAppStyles.js
+++ b/src/styles/XXLargeAppStyles.js
@@ -3,5 +3,6 @@ import { XXLargeCoreStyles } from "@wrappid/core";
 export default class XXLargeAppStyles extends XXLargeCoreStyles {
   constructor() {
     super();
-    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };}
+    this.style = {};
+  }
 }

--- a/src/styles/XXLargeAppStyles.js
+++ b/src/styles/XXLargeAppStyles.js
@@ -3,6 +3,5 @@ import { XXLargeCoreStyles } from "@wrappid/core";
 export default class XXLargeAppStyles extends XXLargeCoreStyles {
   constructor() {
     super();
-    this.style = {/**************************************************       * Using XXLargeUtilityStyles example   *************************************************/};
-  }
+    this.style = { /*************************************************** Using defaultUtilityStyles example * usingDefaultUtilityStyles: { ...this.defaultUtilityStyles.anyUtlityStyles }, *************************************************/ };}
 }


### PR DESCRIPTION
remove 'usingSmallUtilityStyles' from -src -styles -DefaultAppStyles.js -LargeAppStyles.js -LargeAppStyles.js -LargeAppStyles.js -XLargeAppStyles.js -XXLargeAppStyles.js

ref: #43

## Description

Clearly describe the changes you've made in this pull request. Explain the purpose and reasoning behind the changes. Reference any relevant issues or discussions using keywords like "Fixes #<issue_number>" or "Resolves #<issue_number>".

## Related Issues

<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
